### PR TITLE
Rewritten feature (#3)

### DIFF
--- a/config/gmrunrc
+++ b/config/gmrunrc
@@ -11,6 +11,11 @@ AlwaysInTerm = ssh telnet ftp lynx mc vi vim pine centericq perldoc man
 Width = 400
 Top = 100
 Left = 200
+# Place window centered by the size of screen
+CenteredByWidth = 0
+CenteredByHeight = 0
+# Place window on active monitor
+UseActiveMonitor = 0
 
 # History size
 History = 256


### PR DESCRIPTION
Now you can place window centered by width, height or both of the active (or default) screen.
In `gmrunrc` there are three new options: **CenteredByWidth**, **CenteredByHeight**, **UseActiveMonitor**
